### PR TITLE
Refactor DandelionShuffle to avoid high cpu use

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1815,6 +1815,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         banman->DumpBanlist();
     }, DUMP_BANS_INTERVAL);
 
+    CConnman* connman = node.connman.get();
+    node.scheduler->scheduleEvery([connman]{
+        connman->ThreadDandelionShuffle();
+    }, std::chrono::milliseconds{5000});
+
 #if HAVE_SYSTEM
     StartupNotify(args);
 #endif

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1788,21 +1788,19 @@ void CConnman::DandelionShuffle() {
     LogPrint(BCLog::DANDELION, "After Dandelion shuffle:\n%s", GetDandelionRoutingDataDebugString());
 }
 
-void CConnman::ThreadDandelionShuffle() {
-    auto current_time = GetTime<std::chrono::microseconds>();
-    auto next_dandelion_shuffle = PoissonNextSend(current_time, DANDELION_SHUFFLE_INTERVAL);
+void CConnman::ThreadDandelionShuffle()
+{
+    LOCK(cs_vNodes);
+    if (!vNodes.size()) {
+        return;
+    }
 
-    while (!interruptNet) {
-        current_time = GetTime<std::chrono::microseconds>();
-        if (current_time > next_dandelion_shuffle) {
-            DandelionShuffle();
-            next_dandelion_shuffle = PoissonNextSend(current_time, DANDELION_SHUFFLE_INTERVAL);
-            // Sleep until the next shuffle time
-            auto sleep_ms = std::chrono::duration_cast<std::chrono::milliseconds>((next_dandelion_shuffle - current_time) / 1000);
-            if (!interruptNet.sleep_for(sleep_ms)) {
-                return;
-            }
-        }
+    auto current_time = GetTime<std::chrono::microseconds>();
+    static auto next_dandelion_shuffle = PoissonNextSend(current_time, DANDELION_SHUFFLE_INTERVAL);
+    LogPrint(BCLog::DANDELION, "Until next shuffle: %d\n", std::chrono::duration_cast<std::chrono::microseconds>(next_dandelion_shuffle - current_time).count());
+    if (current_time > next_dandelion_shuffle) {
+        DandelionShuffle();
+        next_dandelion_shuffle = PoissonNextSend(current_time, DANDELION_SHUFFLE_INTERVAL);
     }
 }
 
@@ -2922,9 +2920,6 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         threadI2PAcceptIncoming =
             std::thread(&util::TraceThread, "i2paccept", [this] { ThreadI2PAcceptIncoming(); });
     }
-
-    // Dandelion shuffle
-    threadDandelionShuffle = std::thread(&util::TraceThread, "dandelion", [this] { ThreadDandelionShuffle(); });
 
     // Dump network addresses
     scheduler.scheduleEvery([this] { DumpAddresses(); }, DUMP_PEERS_INTERVAL);

--- a/src/net.h
+++ b/src/net.h
@@ -982,6 +982,7 @@ public:
     bool insertDandelionEmbargo(const uint256& hash, const std::chrono::seconds& embargo);
     bool isTxDandelionEmbargoed(const uint256& hash) const;
     bool removeDandelionEmbargo(const uint256& hash);
+    void ThreadDandelionShuffle();
 
     /** Attempts to obfuscate tx time through exponentially distributed emitting.
         Works assuming that a single interval is used.
@@ -1038,9 +1039,7 @@ private:
     void SocketHandler();
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
-    void ThreadDandelionShuffle();
     std::string GetDandelionRoutingDataDebugString() const;
-
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 


### PR DESCRIPTION
Instead of having DandelionShuffle() run as an independent thread, we set it up as a function called once every 5 seconds by the scheduler. This way it runs and falls through (and exits) if it has nothing to do; avoiding the high cpu loop that was occurring beforehand.